### PR TITLE
Switch to Environment Files

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check cache
         id: verify-cache
         run: |
-          echo "::set-output name=heads::`git ls-remote https://github.com/theos/theos | head -n 1 | cut -f 1`-`git ls-remote https://github.com/theos/sdks | head -n 1 | cut -f 1`"
+          echo "heads=`git ls-remote https://github.com/theos/theos | head -n 1 | cut -f 1`-`git ls-remote https://github.com/theos/sdks | head -n 1 | cut -f 1`" >> $GITHUB_OUTPUT
 
       - name: Use cache
         uses: actions/cache@v2
@@ -47,7 +47,7 @@ jobs:
 
       - name: Retrieve version
         id: version
-        run: echo "::set-output name=__ENMITY_VERSION::$(cat control | grep -E 'Version:(.*)' | awk '{ print $2 }')"   
+        run: echo "__ENMITY_VERSION=$(cat control | grep -E 'Version:(.*)' | awk '{ print $2 }')" >> $GITHUB_OUTPUT   
 
       - name: Build deb
         run: |


### PR DESCRIPTION
per [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/):

"set-output" has been deprecated in favor of environment files.
` run: echo "::set-output name={name}::{value}"   >>   run: echo "{name}={value}" >> $GITHUB_OUTPUT`

this change reflects on this posting, and now uses environment files.
this was tested and indeed works. 

see the following:
[successful action run](https://github.com/sukarodo/tweak/actions/runs/4710344469/jobs/8353927529)
[successful release](https://github.com/sukarodo/tweak/releases/tag/v2.2.4)

there are still set-output errors due to [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases). 
that can be solved via a fork or (hopefully) a pr.

![image](https://user-images.githubusercontent.com/38664452/232258736-fef4391d-eeee-48e4-aa74-067dce496ede.png)
