### PR TITLE
Fix BUNDLE_PATH and horrible lag when using themes with Image BGs

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Build dev rootless deb
         run: |
           rm -f packages/*
-          echo $"$(sed 's/Name\:.*/Name\: Enmity (Rootless)/' control)" > control
-          echo $"$(sed 's/Package\:.*/Package\: app.enmity.rootless/' control)" > control
+          echo $"$(sed 's/Name\:.*/Name\: Enmity (Dev Rootless)/' control)" > control
+          echo $"$(sed 's/Package\:.*/Package\: app.enmity.dev.rootless/' control)" > control
           gmake clean package FINALPACKAGE=1 DEVTOOLS=1 THEOS_PACKAGE_SCHEME=rootless
           mv $(find packages -name "*.deb" -print -quit) out/Enmity.Rootless.Development.deb
 

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: app.enmity
 Name: Enmity
-Version: 2.2.4
+Version: 2.2.5
 Architecture: iphoneos-arm
 Description: The power of addons, all in your hand.
 Maintainer: Rosie

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"scripts": {
-		"build": "rm -f packages/* && gmake clean package FINALPACKAGE=1 && mv $(find packages -name \"*.deb\") packages/Enmity.Debug.deb"
+		"build": "rm -f packages/* && gmake clean package FINALPACKAGE=1 DEVTOOLS=1 && mv $(find packages -name \"*.deb\") packages/Enmity.Debug.deb"
 	},
 	"dependencies": {
 		"@rollup/plugin-commonjs": "^22.0.1",

--- a/src/Enmity.h
+++ b/src/Enmity.h
@@ -8,7 +8,7 @@
 
 #define ENMITY_PATH [NSString stringWithFormat:@"%@/%@", NSHomeDirectory(), @"Documents/Enmity.js"]
 #define ENMITY_SOURCE [NSURL URLWithString:@"enmity"]
-#define VERSION @"2.2.4"
+#define VERSION @"2.2.5"
 #define TYPE @"Regular"
 
 // Disable logs in release mode

--- a/src/Theme.xi
+++ b/src/Theme.xi
@@ -478,7 +478,8 @@ HOOK_TABLE_CELL(DCDLoadingTableViewCell)
 
 	NSString *url = getBackgroundURL();
 
-	UIView *subview = self.subviews[[self.subviews count] >= 3 ? [self.subviews count] - 3 : 0];
+	int count = [self.subviews count];
+	UIView *subview = self.subviews[(count >= 3 && count <= 5) ? 2 : 0];
 
 	if (subview && [subview isKindOfClass:[UIImageView class]]) {
 		return NSLog(@"Image is a UIImageView!: %@", (id)[NSNumber numberWithBool:[subview isKindOfClass:[UIImageView class]] ]);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -3,7 +3,7 @@
 #import "../headers/RCTCxxBridge.h"
 
 # ifdef THEOS_PACKAGE_INSTALL_PREFIX
-#   define BUNDLE_PATH @THEOS_PACKAGE_INSTALL_PREFIX "/Library/Application Support/Enmity/EnmityFiles.bundle"]
+#   define BUNDLE_PATH @THEOS_PACKAGE_INSTALL_PREFIX "/Library/Application Support/Enmity/EnmityFiles.bundle"
 # else
 #   define BUNDLE_PATH @"/Library/Application Support/Enmity/EnmityFiles.bundle"
 # endif

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -3,7 +3,7 @@
 #import "../headers/RCTCxxBridge.h"
 
 # ifdef THEOS_PACKAGE_INSTALL_PREFIX
-#   define ENMITY_PATH [NSString stringWithFormat:@"%@/%@", THEOS_PACKAGE_INSTALL_PREFIX, @"/Library/Application Support/Enmity/EnmityFiles.bundle"]
+#   define BUNDLE_PATH [NSString stringWithFormat:@"%@/%@", THEOS_PACKAGE_INSTALL_PREFIX, @"/Library/Application Support/Enmity/EnmityFiles.bundle"]
 # else
 #   define BUNDLE_PATH @"/Library/Application Support/Enmity/EnmityFiles.bundle"
 # endif

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -3,7 +3,7 @@
 #import "../headers/RCTCxxBridge.h"
 
 # ifdef THEOS_PACKAGE_INSTALL_PREFIX
-#   define BUNDLE_PATH [NSString stringWithFormat:@"%@/%@", THEOS_PACKAGE_INSTALL_PREFIX, @"/Library/Application Support/Enmity/EnmityFiles.bundle"]
+#   define BUNDLE_PATH @THEOS_PACKAGE_INSTALL_PREFIX "/Library/Application Support/Enmity/EnmityFiles.bundle"]
 # else
 #   define BUNDLE_PATH @"/Library/Application Support/Enmity/EnmityFiles.bundle"
 # endif


### PR DESCRIPTION
* Uses the BUNDLE_PATH constant instead of the ENMITY_PATH constant which fixes the tweak not building through the Action.
* Add a different Package Identifier to the Rootless Dev tweak as I forgot to do that beforehand
* Fix the extreme lag when having a theme with an Image BG.

**Original:**
```objc
UIView *subview = self.subviews[[self.subviews count] >= 3 ? [self.subviews count] - 3 : 0];
```
**New:**
```objc
int count = [self.subviews count];
UIView *subview = self.subviews[(count >= 3 && count <= 5) ? 2 : 0];
```