### PR TITLE
Use the same identifier for rootful and rootless build

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -66,16 +66,14 @@ jobs:
       - name: Build rootless deb
         run: |
           rm -f packages/*
-          echo $"$(sed 's/Name\:.*/Name\: Enmity (Rootless)/' control)" > control
-          echo $"$(sed 's/Package\:.*/Package\: app.enmity.rootless/' control)" > control
           gmake clean package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME=rootless
           mv $(find packages -name "*.deb" -print -quit) out/Enmity.Rootless.deb
 
       - name: Build dev rootless deb
         run: |
           rm -f packages/*
-          echo $"$(sed 's/Name\:.*/Name\: Enmity (Dev Rootless)/' control)" > control
-          echo $"$(sed 's/Package\:.*/Package\: app.enmity.dev.rootless/' control)" > control
+          echo $"$(sed 's/Name\:.*/Name\: Enmity (Dev)/' control)" > control
+          echo $"$(sed 's/Package\:.*/Package\: app.enmity.dev/' control)" > control
           gmake clean package FINALPACKAGE=1 DEVTOOLS=1 THEOS_PACKAGE_SCHEME=rootless
           mv $(find packages -name "*.deb" -print -quit) out/Enmity.Rootless.Development.deb
 


### PR DESCRIPTION
We should use the same identifier for rootful and rootless build as the package manager will handle these packages and hide rootful one on rootless jb and vice versa.
https://twitter.com/opa334dev/status/1649873013767131138