### PR TITLE
Replace Discord.ipa with URL input for release workflow

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,7 +1,5 @@
 name: Create a stable release
 on:
-  push:
-  pull_request:
   workflow_dispatch:
     inputs:
       discord_ipa_url:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -46,7 +46,7 @@ jobs:
       
       - name: Download Discord IPA
         run: |
-          curl -L {{ inputs.discord_ipa_url }} -o ${{ github.workspace }}/Discord.ipa
+          curl -L ${{ inputs.discord_ipa_url }} -o ${{ github.workspace }}/Discord.ipa
 
       - name: Patch Discord
         run : |

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -3,6 +3,12 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      discord_ipa_url:
+        description: "Discord IPA URL"
+        default: ""
+        required: true
+        type: string
 
 jobs:
   build:
@@ -39,6 +45,10 @@ jobs:
         run : |
           curl -L https://github.com/enmity-mod/patcher/releases/latest/download/patcher.mac-amd64 -o ${{ github.workspace }}/patcher
           chmod +x patcher
+      
+      - name: Download Discord IPA
+        run: |
+          curl -L {{ inputs.discord_ipa_url }} -o ${{ github.workspace }}/Discord.ipa
 
       - name: Patch Discord
         run : |

--- a/Discord.ipa
+++ b/Discord.ipa
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:838aa5c34f84e40e859170a253195342038d485acaad05e057745250359f0a7b
-size 97490185


### PR DESCRIPTION
- Delete Discord.ipa from the root of the repository
- Add the IPA URL as an input field for the stable release workflow
- Don't run the release workflow automatically